### PR TITLE
docs: add `permissions` to example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,21 @@ You can use this action in an existing workflow and have it run after a linter o
 
 ```yaml
 name: 'markdownlint'
+
 on:
   pull_request:
     paths: ['**/*.md']
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v13
+      - uses: DavidAnson/markdownlint-cli2-action@v15
         with:
           fix: true
           globs: '**/*.md'


### PR DESCRIPTION
This pull request assigns [permissions](https://docs.github.com/actions/using-jobs/assigning-permissions-to-jobs) assignment to the example workflow in the README. This may be required in some situations, such as when [GITHUB_TOKEN permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) are set to restrictive by default. 