### PR TITLE
fix: Only select diff lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const pullRequestFiles = (
 ).data.map((file) => file.filename)
 
 // Get the diff between the head branch and the base branch (limit to the files in the pull request)
-const diff = await getExecOutput('git', ['diff', '--', ...pullRequestFiles], {
+const diff = await getExecOutput('git', ['diff', '--unified=0', '--', ...pullRequestFiles], {
   silent: true,
 })
 


### PR DESCRIPTION
Fixes https://github.com/parkerbxyz/suggest-changes/issues/28.

We can pass the `--unified=0` argument to the `git diff` command to only return actual diffs, without any contextual lines before and after. The action doesn't really need to select lines before and after the suggestion since the suggestion is annotated in GitHub and users can view the exact location of the changes in the UI.

This fixes the problem where the suggestion contains lines that are not part of the diff.

---

<details>
  <summary>Example index.js</summary>

```
     1	const SOME_VARIABLE = "test";
     2	const SOME_OTHER_VARIABLE_TO_ADD_LINES = "new-test";
     3
     4	export function main(args) {
     5	  console.log("Hello, World!");
     6	}
     7
     8	function foo() {
     9	  console.log("foo");
    10	  console.log("bar");
    11	  console.log("baz");
    12	}
    13
    14	function bar() {
    15	  console.log("baz");
    16	  console.log("bar");
    17	  console.log("foo");
    18	}
```
</details>

<details>
  <summary>Line deletion output</summary>

If we want to delete the line 9, `git diff` will output:
```diff
diff --git a/index.js b/index.js
index e7fad5537..bfe5e5fff 100644
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ export function main(args) {
 }

 function foo() {
-  console.log("foo");
   console.log("bar");
   console.log("baz");
 }
```

while `git diff --unified=0` will output:
```diff
diff --git a/index.js b/index.js
index e7fad5537..bfe5e5fff 100644
--- a/index.js
+++ b/index.js
@@ -9 +8,0 @@ function foo() {
-  console.log("foo");
```
</details>

<details>
  <summary>Line addition output</summary>

If we want to add a line above the line 9, `git diff` will output:
```diff
diff --git a/index.js b/index.js
index e7fad5537..2c4768e93 100644
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ export function main(args) {
 }

 function foo() {
+  console.log("foo");
   console.log("foo");
   console.log("bar");
   console.log("baz");

```

while `git diff --unified=0` will output:
```diff
diff --git a/index.js b/index.js
index e7fad5537..2c4768e93 100644
--- a/index.js
+++ b/index.js
@@ -8,0 +9 @@ function foo() {
+  console.log("foo");
```
</details>

<details>
  <summary>Line modification output</summary>

If we want to change the line 9, `git diff` will output:
```diff
diff --git a/index.js b/index.js
index e7fad5537..5a7c6f20e 100644
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ export function main(args) {
 }

 function foo() {
-  console.log("foo");
+  console.log("oof");
   console.log("bar");
   console.log("baz");
 }
```

while `git diff --unified=0` will output:
```diff
diff --git a/index.js b/index.js
index e7fad5537..5a7c6f20e 100644
--- a/index.js
+++ b/index.js
@@ -9 +9 @@ function foo() {
-  console.log("foo");
+  console.log("oof");
```
</details>
