### PR TITLE
fix: do not create duplicate review comments

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -53129,7 +53129,7 @@ const comments = changedFiles.flatMap(({ path, chunks }) =>
       ;(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.debug)(`Number of lines: ${fromFileRange.lines}`)
       ;(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.debug)(`Changes: ${JSON.stringify(changes)}`)
       const newComment =
-        fromFileRange.lines === 1
+        fromFileRange.lines <= 1
           ? createSingleLineComment(path, fromFileRange, changes)
           : createMultiLineComment(path, fromFileRange, changes)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -53067,9 +53067,7 @@ const pullRequestFiles = (
 const diff = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_1__.getExecOutput)(
   'git',
   ['diff', '--unified=0', '--', ...pullRequestFiles],
-  {
-    silent: true,
-  }
+  { silent: true }
 )
 
 ;(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.debug)(`Diff output: ${diff.stdout}`)

--- a/dist/index.js
+++ b/dist/index.js
@@ -53118,30 +53118,38 @@ const existingComments = (
   await octokit.pulls.listReviewComments({ owner, repo, pull_number })
 ).data
 
+// Function to generate a unique key for a comment
+const generateCommentKey = (comment) =>
+  `${comment.path}:${comment.line ?? ''}:${comment.start_line ?? ''}:${
+    comment.body
+  }`
+
+// Create a Set of existing comment keys for faster lookup
+const existingCommentKeys = new Set(existingComments.map(generateCommentKey))
+
 // Create an array of comments with suggested changes for each chunk of each changed file
-const comments = changedFiles
-  .flatMap(({ path, chunks }) =>
-    chunks.map(({ fromFileRange, changes }) => {
-      ;(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.debug)(`Starting line: ${fromFileRange.start}`)
-      ;(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.debug)(`Number of lines: ${fromFileRange.lines}`)
-      ;(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.debug)(`Changes: ${JSON.stringify(changes)}`)
-      const comment =
-        fromFileRange.lines <= 1
-          ? createSingleLineComment(path, fromFileRange, changes)
-          : createMultiLineComment(path, fromFileRange, changes)
+const comments = changedFiles.flatMap(({ path, chunks }) =>
+  chunks.flatMap(({ fromFileRange, changes }) => {
+    ;(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.debug)(`Starting line: ${fromFileRange.start}`)
+    ;(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.debug)(`Number of lines: ${fromFileRange.lines}`)
+    ;(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.debug)(`Changes: ${JSON.stringify(changes)}`)
 
-      // Check if the new comment already exists
-      const isDuplicate = existingComments.some(
-        (existingComment) =>
-          existingComment.path === comment.path &&
-          existingComment.line === comment.line &&
-          existingComment.body === comment.body
-      )
+    const comment =
+      fromFileRange.lines <= 1
+        ? createSingleLineComment(path, fromFileRange, changes)
+        : createMultiLineComment(path, fromFileRange, changes)
 
-      return isDuplicate ? null : comment
-    })
-  )
-  .filter((comment) => comment !== null)
+    // Generate key for the new comment
+    const commentKey = generateCommentKey(comment)
+
+    // Check if the new comment already exists
+    if (existingCommentKeys.has(commentKey)) {
+      return []
+    }
+
+    return [comment]
+  })
+)
 
 // Create a review with the suggested changes if there are any
 if (comments.length > 0) {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { debug, getInput } from '@actions/core'
 import { getExecOutput } from '@actions/exec'
 import { Octokit } from '@octokit/action'
@@ -24,9 +26,13 @@ const pullRequestFiles = (
 ).data.map((file) => file.filename)
 
 // Get the diff between the head branch and the base branch (limit to the files in the pull request)
-const diff = await getExecOutput('git', ['diff', '--unified=0', '--', ...pullRequestFiles], {
-  silent: true,
-})
+const diff = await getExecOutput(
+  'git',
+  ['diff', '--unified=0', '--', ...pullRequestFiles],
+  {
+    silent: true,
+  }
+)
 
 debug(`Diff output: ${diff.stdout}`)
 
@@ -57,10 +63,10 @@ function createSingleLineComment(path, fromFileRange, changes) {
 }
 
 function createMultiLineComment(path, fromFileRange, changes) {
-  const startLine = fromFileRange.start;
+  const startLine = fromFileRange.start
   // The last line of the chunk is the start line plus the number of lines in the chunk
   // minus 1 to account for the start line being included in fromFileRange.lines
-  const endLine = fromFileRange.start + fromFileRange.lines - 1;
+  const endLine = fromFileRange.start + fromFileRange.lines - 1
 
   return {
     path,
@@ -79,24 +85,27 @@ const existingComments = (
 
 // Create an array of comments with suggested changes for each chunk of each changed file
 const comments = changedFiles.flatMap(({ path, chunks }) =>
-  chunks.map(({ fromFileRange, changes }) => {
-    debug(`Starting line: ${fromFileRange.start}`)
-    debug(`Number of lines: ${fromFileRange.lines}`)
-    debug(`Changes: ${JSON.stringify(changes)}`)
-    const newComment = fromFileRange.lines === 1
-      ? createSingleLineComment(path, fromFileRange, changes)
-      : createMultiLineComment(path, fromFileRange, changes)
+  chunks
+    .map(({ fromFileRange, changes }) => {
+      debug(`Starting line: ${fromFileRange.start}`)
+      debug(`Number of lines: ${fromFileRange.lines}`)
+      debug(`Changes: ${JSON.stringify(changes)}`)
+      const newComment =
+        fromFileRange.lines === 1
+          ? createSingleLineComment(path, fromFileRange, changes)
+          : createMultiLineComment(path, fromFileRange, changes)
 
-    // Check if the new comment already exists
-    const isDuplicate = existingComments.some(
-      (existingComment) =>
-        existingComment.path === newComment.path &&
-        existingComment.line === newComment.line &&
-        existingComment.body === newComment.body
-    )
+      // Check if the new comment already exists
+      const isDuplicate = existingComments.some(
+        (existingComment) =>
+          existingComment.path === newComment.path &&
+          existingComment.line === newComment.line &&
+          existingComment.body === newComment.body
+      )
 
-    return isDuplicate ? null : newComment
-  }).filter(Boolean)
+      return isDuplicate ? null : newComment
+    })
+    .filter(Boolean)
 )
 
 // Create a review with the suggested changes if there are any

--- a/index.js
+++ b/index.js
@@ -85,12 +85,16 @@ const comments = changedFiles.flatMap(({ path, chunks }) =>
       : createMultiLineComment(path, fromFileRange, changes)
 
     // Check if the new comment already exists
-    const isDuplicate = existingComments.some(
-      (existingComment) =>
+    const isDuplicate = existingComments.some((existingComment) => {
+      return (
         existingComment.path === newComment.path &&
+        existingComment.start_line === newComment.start_line &&
         existingComment.line === newComment.line &&
+        existingComment.start_side === newComment.start_side &&
+        existingComment.side === newComment.side &&
         existingComment.body === newComment.body
-    )
+      )
+    })
 
     return isDuplicate ? null : newComment
   }).filter(Boolean)

--- a/index.js
+++ b/index.js
@@ -81,9 +81,9 @@ const existingComments = (
 ).data
 
 // Create an array of comments with suggested changes for each chunk of each changed file
-const comments = changedFiles.flatMap(({ path, chunks }) =>
-  chunks
-    .map(({ fromFileRange, changes }) => {
+const comments = changedFiles
+  .flatMap(({ path, chunks }) =>
+    chunks.map(({ fromFileRange, changes }) => {
       debug(`Starting line: ${fromFileRange.start}`)
       debug(`Number of lines: ${fromFileRange.lines}`)
       debug(`Changes: ${JSON.stringify(changes)}`)
@@ -102,8 +102,8 @@ const comments = changedFiles.flatMap(({ path, chunks }) =>
 
       return isDuplicate ? null : comment
     })
-    .filter(Boolean)
-)
+  )
+  .filter((comment) => comment !== null)
 
 // Create a review with the suggested changes if there are any
 if (comments.length > 0) {

--- a/index.js
+++ b/index.js
@@ -29,9 +29,7 @@ const pullRequestFiles = (
 const diff = await getExecOutput(
   'git',
   ['diff', '--unified=0', '--', ...pullRequestFiles],
-  {
-    silent: true,
-  }
+  { silent: true }
 )
 
 debug(`Diff output: ${diff.stdout}`)

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ const comments = changedFiles.flatMap(({ path, chunks }) =>
       debug(`Number of lines: ${fromFileRange.lines}`)
       debug(`Changes: ${JSON.stringify(changes)}`)
       const newComment =
-        fromFileRange.lines === 1
+        fromFileRange.lines <= 1
           ? createSingleLineComment(path, fromFileRange, changes)
           : createMultiLineComment(path, fromFileRange, changes)
 

--- a/index.js
+++ b/index.js
@@ -57,12 +57,15 @@ function createSingleLineComment(path, fromFileRange, changes) {
 }
 
 function createMultiLineComment(path, fromFileRange, changes) {
+  const startLine = fromFileRange.start;
+  // The last line of the chunk is the start line plus the number of lines in the chunk
+  // minus 1 to account for the start line being included in fromFileRange.lines
+  const endLine = fromFileRange.start + fromFileRange.lines - 1;
+
   return {
     path,
-    start_line: fromFileRange.start,
-    // The last line of the chunk is the start line plus the number of lines in the chunk
-    // minus 1 to account for the start line being included in fromFileRange.lines
-    line: fromFileRange.start + fromFileRange.lines - 1,
+    start_line: startLine,
+    line: endLine,
     start_side: 'RIGHT',
     side: 'RIGHT',
     body: generateSuggestionBody(changes),
@@ -80,7 +83,7 @@ const comments = changedFiles.flatMap(({ path, chunks }) =>
     debug(`Starting line: ${fromFileRange.start}`)
     debug(`Number of lines: ${fromFileRange.lines}`)
     debug(`Changes: ${JSON.stringify(changes)}`)
-    const newComment = fromFileRange.start === fromFileRange.lines && changes.length === 2
+    const newComment = fromFileRange.lines === 1
       ? createSingleLineComment(path, fromFileRange, changes)
       : createMultiLineComment(path, fromFileRange, changes)
 

--- a/index.js
+++ b/index.js
@@ -63,15 +63,12 @@ function createSingleLineComment(path, fromFileRange, changes) {
 }
 
 function createMultiLineComment(path, fromFileRange, changes) {
-  const startLine = fromFileRange.start
-  // The last line of the chunk is the start line plus the number of lines in the chunk
-  // minus 1 to account for the start line being included in fromFileRange.lines
-  const endLine = fromFileRange.start + fromFileRange.lines - 1
-
   return {
     path,
-    start_line: startLine,
-    line: endLine,
+    start_line: fromFileRange.start,
+    // The last line of the chunk is the start line plus the number of lines in the chunk
+    // minus 1 to account for the start line being included in fromFileRange.lines
+    line: fromFileRange.start + fromFileRange.lines - 1,
     start_side: 'RIGHT',
     side: 'RIGHT',
     body: generateSuggestionBody(changes),

--- a/index.js
+++ b/index.js
@@ -85,16 +85,12 @@ const comments = changedFiles.flatMap(({ path, chunks }) =>
       : createMultiLineComment(path, fromFileRange, changes)
 
     // Check if the new comment already exists
-    const isDuplicate = existingComments.some((existingComment) => {
-      return (
+    const isDuplicate = existingComments.some(
+      (existingComment) =>
         existingComment.path === newComment.path &&
-        existingComment.start_line === newComment.start_line &&
         existingComment.line === newComment.line &&
-        existingComment.start_side === newComment.start_side &&
-        existingComment.side === newComment.side &&
         existingComment.body === newComment.body
-      )
-    })
+    )
 
     return isDuplicate ? null : newComment
   }).filter(Boolean)


### PR DESCRIPTION
Fixes #37

Prevent repetitive reviews for the same diff when the workflow is triggered multiple times.

* **Fetch existing review comments**: Add a function to fetch existing review comments using `octokit.pulls.listReviewComments`.
* **Check for duplicate comments**: Modify the logic to check for existing comments before creating new ones. Compare new comments with existing ones to avoid duplicates.
* **Update review creation**: Update `octokit.pulls.createReview` call to only include new comments if there are any.

**To do:**

- Restore `ts-check`
- Fix typing errors
- Test changes

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/parkerbxyz/suggest-changes/issues/37?shareId=8aeb32bd-a987-4809-af39-544f34799085).