### PR TITLE
fix: single line comment logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,11 +77,11 @@ const comments = changedFiles.flatMap(({ path, chunks }) =>
     debug(`Starting line: ${fromFileRange.start}`)
     debug(`Number of lines: ${fromFileRange.lines}`)
     debug(`Changes: ${JSON.stringify(changes)}`)
-    if (fromFileRange.start === fromFileRange.lines && changes.length === 2) {
-      return createSingleLineComment(path, fromFileRange, changes)
-    } else {
-      return createMultiLineComment(path, fromFileRange, changes)
-    }
+    const comment =
+      fromFileRange.lines <= 1
+        ? createSingleLineComment(path, fromFileRange, changes)
+        : createMultiLineComment(path, fromFileRange, changes)
+    return comment
   })
 )
 


### PR DESCRIPTION
Fixes the conditional logic for determining whether to create a single-line or multi-line comment in the `index.js` file.