### PR TITLE
build: replace release-please GitHub App with action

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,1 +1,0 @@
-handleGHRelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,15 @@ name: release
 
 on:
   workflow_dispatch:
-  release:
-    types: [released]
+  push:
+    branches: [main]
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  release:
-    uses: parkerbxyz/.github/.github/workflows/release.yml@main
-    secrets: inherit
+  release-please:
+    uses: parkerbxyz/.github/.github/workflows/release-please.yml@main
+    with:
+      release-type: 'node'


### PR DESCRIPTION
Replaces the release-please GitHub app configuration with the GitHub Action because the Release Please GitHub App was deprecated on 2025-08-13: https://github.com/apps/release-please.