### PR TITLE
fix: order batched review suggestions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -534,6 +534,22 @@ function buildCommentDraft(
 }
 
 /**
+ * Sort comments so batched suggestion application processes lower lines before higher lines.
+ */
+export function sortCommentsForBatch(
+  comments: ReviewCommentDraft[]
+): ReviewCommentDraft[] {
+  return comments.toSorted((a, b) => {
+    const pathCompare = a.path.localeCompare(b.path)
+    if (pathCompare !== 0) return pathCompare
+
+    const aStart = a.start_line ?? a.line
+    const bStart = b.start_line ?? b.line
+    return bStart - aStart || b.line - a.line
+  })
+}
+
+/**
  * Partition an array into two arrays based on a predicate.
  */
 function partition<T>(
@@ -814,7 +830,9 @@ export async function run({
   }
 
   const reviewComments = comments.slice(0, MAX_COMMENTS_PER_REVIEW)
-  logComments('Suggestions to be included in review:', reviewComments)
+  // Submit lower lines first so batched application does not shift later anchors.
+  const orderedReviewComments = sortCommentsForBatch(reviewComments)
+  logComments('Suggestions to be included in review:', orderedReviewComments)
 
   const reviewBody = createReviewBodyWithLimitNotice(
     body,
@@ -829,7 +847,7 @@ export async function run({
     commit_id,
     body: reviewBody,
     event,
-    comments: reviewComments,
+    comments: orderedReviewComments,
   })
   info(
     `Review created successfully with ${reviewComments.length} suggestion(s).`

--- a/src/index.ts
+++ b/src/index.ts
@@ -543,9 +543,12 @@ export function sortCommentsForBatch(
     const pathCompare = a.path.localeCompare(b.path)
     if (pathCompare !== 0) return pathCompare
 
+    const lineCompare = b.line - a.line
+    if (lineCompare !== 0) return lineCompare
+
     const aStart = a.start_line ?? a.line
     const bStart = b.start_line ?? b.line
-    return bStart - aStart || b.line - a.line
+    return bStart - aStart
   })
 }
 

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -34,7 +34,7 @@ async function generateDiff(beforeFile, afterFile) {
 /**
  * Apply a suggestion to file content
  * @param {string} content - The original file content
- * @param {import('../index.js').ReviewCommentDraft} suggestion - The suggestion to apply
+ * @param {import('../src/types').ReviewCommentDraft} suggestion - The suggestion to apply
  * @returns {string} The content with the suggestion applied
  */
 function applySuggestion(content, suggestion) {
@@ -75,7 +75,7 @@ function applySuggestion(content, suggestion) {
  * Apply multiple suggestions to file content in the correct order
  * Suggestions must be applied in reverse order (bottom to top) to avoid line number shifts
  * @param {string} content - The original file content
- * @param {Array<import('../index.js').ReviewCommentDraft>} suggestions - The suggestions to apply
+ * @param {Array<import('../src/types').ReviewCommentDraft>} suggestions - The suggestions to apply
  * @returns {string} The content with all suggestions applied
  */
 function applySuggestions(content, suggestions) {
@@ -97,7 +97,7 @@ function applySuggestions(content, suggestions) {
 /**
  * Apply multiple suggestions to file content in the generated order.
  * @param {string} content - The original file content
- * @param {Array<import('../index.js').ReviewCommentDraft>} suggestions - The suggestions to apply
+ * @param {Array<import('../src/types').ReviewCommentDraft>} suggestions - The suggestions to apply
  * @returns {string} The content with all suggestions applied
  */
 function applySuggestionsInGeneratedOrder(content, suggestions) {

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -3,7 +3,11 @@ import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, test } from 'node:test'
 import parseGitDiff from 'parse-git-diff'
-import { generateReviewComments, getGitDiff } from '../src/index.ts'
+import {
+  generateReviewComments,
+  getGitDiff,
+  sortCommentsForBatch,
+} from '../src/index.ts'
 
 const fixtureDir = 'test/fixtures'
 
@@ -85,6 +89,20 @@ function applySuggestions(content, suggestions) {
 
   let result = content
   for (const suggestion of sortedSuggestions) {
+    result = applySuggestion(result, suggestion)
+  }
+  return result
+}
+
+/**
+ * Apply multiple suggestions to file content in the generated order.
+ * @param {string} content - The original file content
+ * @param {Array<import('../index.js').ReviewCommentDraft>} suggestions - The suggestions to apply
+ * @returns {string} The content with all suggestions applied
+ */
+function applySuggestionsInGeneratedOrder(content, suggestions) {
+  let result = content
+  for (const suggestion of suggestions) {
     result = applySuggestion(result, suggestion)
   }
   return result
@@ -188,5 +206,21 @@ describe('Integration Tests', () => {
           )
         })
       })
+  })
+
+  describe('Batch safety', () => {
+    test('new-file-issue suggestions should apply safely in review batch order', async () => {
+      const beforeFile = 'test/fixtures/new-file-issue/before.md'
+      const afterFile = 'test/fixtures/new-file-issue/after.md'
+      const beforeContent = normalizeLineEndings(readFileSync(beforeFile, 'utf8'))
+      const afterContent = normalizeLineEndings(readFileSync(afterFile, 'utf8'))
+      const diffContent = await generateDiff(beforeFile, afterFile)
+      const parsed = parseGitDiff(diffContent)
+      const suggestions = sortCommentsForBatch(generateReviewComments(parsed))
+
+      const result = applySuggestionsInGeneratedOrder(beforeContent, suggestions)
+
+      assert.strictEqual(result, afterContent)
+    })
   })
 })

--- a/test/grouping-blank-lines.test.ts
+++ b/test/grouping-blank-lines.test.ts
@@ -8,7 +8,7 @@ import { generateSuggestionBody, groupChangesForSuggestions } from '../src/index
 describe('Grouping algorithm for blank line insertions', () => {
   test('should create separate groups for each unchanged line followed by blank addition', () => {
     // Simulates adding blank lines after Line A and Line B: Line A (add blank line), Line B (add blank line), Line C
-    /** @type {import('../index.js').AnyLineChange[]} */
+    /** @type {import('../src/types').AnyLineChange[]} */
     const changes = [
       { type: 'UnchangedLine', lineBefore: 1, lineAfter: 1, content: 'Line A' },
       { type: 'AddedLine', lineAfter: 2, content: '' },
@@ -37,7 +37,7 @@ describe('Grouping algorithm for blank line insertions', () => {
   })
 
   test('should generate correct suggestions for blank line insertions', () => {
-    /** @type {import('../index.js').AnyLineChange[]} */
+    /** @type {import('../src/types').AnyLineChange[]} */
     const changes = [
       {
         type: 'UnchangedLine',
@@ -69,7 +69,7 @@ describe('Grouping algorithm for blank line insertions', () => {
   })
 
   test('should handle multiple blank lines being added', () => {
-    /** @type {import('../index.js').AnyLineChange[]} */
+    /** @type {import('../src/types').AnyLineChange[]} */
     const changes = [
       { type: 'UnchangedLine', lineBefore: 1, lineAfter: 1, content: 'Line A' },
       { type: 'AddedLine', lineAfter: 2, content: '' },
@@ -86,7 +86,7 @@ describe('Grouping algorithm for blank line insertions', () => {
   })
 
   test('should not split groups when there are deletions', () => {
-    /** @type {import('../index.js').AnyLineChange[]} */
+    /** @type {import('../src/types').AnyLineChange[]} */
     const changes = [
       { type: 'UnchangedLine', lineBefore: 1, lineAfter: 1, content: 'Line A' },
       { type: 'DeletedLine', lineBefore: 2, content: 'Old line' },
@@ -103,7 +103,7 @@ describe('Grouping algorithm for blank line insertions', () => {
   })
 
   test('should handle blank line at end of file', () => {
-    /** @type {import('../index.js').AnyLineChange[]} */
+    /** @type {import('../src/types').AnyLineChange[]} */
     const changes = [
       {
         type: 'UnchangedLine',

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -6,6 +6,7 @@ import {
   generateCommentKey,
   generateReviewComments,
   run,
+  sortCommentsForBatch,
 } from '../src/index.ts'
 
 describe('Unit Tests', () => {
@@ -94,6 +95,29 @@ describe('Unit Tests', () => {
       assert.strictEqual(
         result,
         '````suggestion\n  Indented line  \n\nWith empty line\n````'
+      )
+    })
+  })
+
+  describe('sortCommentsForBatch', () => {
+    test('should order multi-line suggestions by end line before start line', () => {
+      const sorted = sortCommentsForBatch([
+        {
+          path: 'file.md',
+          line: 90,
+          body: 'single-line suggestion',
+        },
+        {
+          path: 'file.md',
+          line: 100,
+          start_line: 1,
+          body: 'multi-line suggestion',
+        },
+      ])
+
+      assert.deepStrictEqual(
+        sorted.map((comment) => comment.body),
+        ['multi-line suggestion', 'single-line suggestion']
       )
     })
   })


### PR DESCRIPTION
Batched suggestion application can shift line anchors when earlier suggestions insert or remove lines before later suggestions. This changes review creation to submit comments from lower lines to higher lines within each file, preserving the existing top-of-file selection for the review comment limit while making batch application safer.

## Summary

- Sort selected review comments by path and descending line before creating the review.
- Keep the 100-comment cap behavior unchanged by sorting after truncation.
- Add a regression test that applies the issue fixture suggestions in generated batch order.

Fixes: #123